### PR TITLE
Ensure socket exists before destroying

### DIFF
--- a/lib60870-C/src/hal/socket/bsd/socket_bsd.c
+++ b/lib60870-C/src/hal/socket/bsd/socket_bsd.c
@@ -438,6 +438,9 @@ Socket_destroy(Socket self)
 
     self->fd = -1;
 
+    if (fd == -1)
+        return;
+
     closeAndShutdownSocket(fd);
 
     Thread_sleep(10);

--- a/lib60870-C/src/hal/socket/linux/socket_linux.c
+++ b/lib60870-C/src/hal/socket/linux/socket_linux.c
@@ -453,6 +453,9 @@ Socket_destroy(Socket self)
 
     self->fd = -1;
 
+    if (fd == -1)
+        return;
+
     closeAndShutdownSocket(fd);
 
     Thread_sleep(10);


### PR DESCRIPTION
This is to ✨hopefully✨  resolve a double-free caused by repeated calls to `Socket_destroy()` for the same socket. Based off of this unmerged PR https://github.com/mz-automation/lib60870/pull/59