### PR TITLE
[LL-739] Destroy Existing Thread Before Reconnecting

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -832,6 +832,11 @@ CS104_Connection_connectAsync(CS104_Connection self)
     self->close = false;
 
 #if (CONFIG_USE_THREADS == 1)
+    if (self->connectionHandlingThread) {
+            Thread_destroy(self->connectionHandlingThread);
+            self->connectionHandlingThread = NULL;
+    }
+
     self->connectionHandlingThread = Thread_create(handleConnection, (void*) self, false);
 
     if (self->connectionHandlingThread)


### PR DESCRIPTION
Our fork of the [lib60870 library](https://github.com/mz-automation/lib60870) is over a hundred commits behind it. I noticed there was a memory leak fix in a part of the connection logic that we would get hung on after ~16k reconnection attempts (1 per minute). 

After bringing in [the patch](https://github.com/mz-automation/lib60870/commit/43d69d48c39181727d83eaed02500744f7723afd), we no longer have that issue. 

