### PR TITLE
AP-1357 cs104: Don't attempt to send start/stopDT if connection is not running.

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -1154,9 +1154,13 @@ encodeIOA(CS104_Connection self, Frame frame, int ioa)
 void
 CS104_Connection_sendStartDT(CS104_Connection self)
 {
+    /* TODO: should add a return value? */
 #if (CONFIG_USE_SEMAPHORES == 1)
     Semaphore_wait(self->conStateLock);
 #endif /* (CONFIG_USE_SEMAPHORES == 1) */
+
+    if (!isRunning(self))
+        return;
 
     self->conState = STATE_WAITING_FOR_STARTDT_CON;
 
@@ -1170,9 +1174,13 @@ CS104_Connection_sendStartDT(CS104_Connection self)
 void
 CS104_Connection_sendStopDT(CS104_Connection self)
 {
+    /* TODO: should add a return value? */
 #if (CONFIG_USE_SEMAPHORES == 1)
     Semaphore_wait(self->conStateLock);
 #endif /* (CONFIG_USE_SEMAPHORES == 1) */
+
+    if (!isRunning(self))
+        return;
 
     confirmOutstandingMessages(self);
 


### PR DESCRIPTION
Otherwise, Socket_write() segfaults when it tries to send to an invalid socket.