### PR TITLE
Revert d88b41d; Add check to prevent overwriting tcp socket

### DIFF
--- a/lib60870-C/src/hal/socket/bsd/socket_bsd.c
+++ b/lib60870-C/src/hal/socket/bsd/socket_bsd.c
@@ -639,9 +639,6 @@ Socket_destroy(Socket self)
 
     self->fd = -1;
 
-    if (fd == -1)
-        return;
-
     closeAndShutdownSocket(fd);
 
     Thread_sleep(10);

--- a/lib60870-C/src/hal/socket/linux/socket_linux.c
+++ b/lib60870-C/src/hal/socket/linux/socket_linux.c
@@ -736,9 +736,6 @@ Socket_destroy(Socket self)
 
     self->fd = -1;
 
-    if (fd == -1)
-        return;
-
     closeAndShutdownSocket(fd);
 
     Thread_sleep(10);

--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -862,7 +862,9 @@ handleConnection(void* parameter)
 
   /*
    * This guard ensures that the socket doesn't get overwritten by another thread,
-   * which could potentially lead to a double-free error.
+   * which could potentially lead to a double-free error. This could happen if the previous
+   * thread is not successfully destroyed in CS104_Connection_connectAsync--we currently do
+   * not check the return value of pthread_join(), which could be an error.
    *
    * This change also accompanies the reversal of two misguided checks that
    * attempted to address double-free errors reported in https://enbala.atlassian.net/browse/LL-480.


### PR DESCRIPTION
- Reverts https://github.com/Enbala/lib60870/pull/1
- Adds check to prevent the socket from being overwritten in `handleConnection` 

See commits for details
